### PR TITLE
fix(create): Adding create_sotransaction support

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,6 +1,7 @@
 const FUNCTION_NAMES = [
     'consolidate',
     'create',
+    'create_sotransaction',
     'delete',
     'getAPISession',
     'getUserPermissions',


### PR DESCRIPTION
@mrlannigan @trainerbill or @mciocchi adding this missing create_sotransaction since the library does not work for me without it.  If there is another way to accomplish that please let me know.