### PR TITLE
added support for atomically returning the key/id when creating

### DIFF
--- a/src/control_function.js
+++ b/src/control_function.js
@@ -58,6 +58,7 @@ class ControlFunction {
         } else {
             this.data = result.data;
         }
+        this.key = result.key;
     }
 
     isSuccessful() {


### PR DESCRIPTION
The key is already being returned in the response body, but this API doesn't store it, so there's no way to access it.